### PR TITLE
Update babel-mk.ini

### DIFF
--- a/locale/mk/babel-mk.ini
+++ b/locale/mk/babel-mk.ini
@@ -48,7 +48,7 @@ page = стр.
 see = види
 also = види истотака
 proof = доказ
-glossaryname = Рецник
+glossaryname = Речник
 
 [captions.licr]
 preface = \CYRP\cyrr\cyre\cyrd\cyrg\cyro\cyrv\cyro\cyrr
@@ -71,7 +71,7 @@ page = \cyrs\cyrt\cyrr.
 see = \cyrv\cyri\cyrd\cyri
 also = \cyrv\cyri\cyrd\cyri\space \cyri\cyrs\cyrt\cyro\cyrt\cyra\cyrk\cyra
 proof = \cyrd\cyro\cyrk\cyra\cyrz
-glossaryname = \CYRR\cyre\cyrc\cyrn\cyri\cyrk
+glossaryname = \CYRR\cyre\cyrch\cyrn\cyri\cyrk
 
 [date.gregorian]
 date.long = [d][ ][MMMM] [y][ ]год.
@@ -108,7 +108,7 @@ days.wide.fri = петок
 days.wide.sat = сабота
 days.wide.sun = недела
 days.abbreviated.mon = пон.
-days.abbreviated.tue = вт.
+days.abbreviated.tue = втор.
 days.abbreviated.wed = сре.
 days.abbreviated.thu = чет.
 days.abbreviated.fri = пет.


### PR DESCRIPTION
Some minor typos fixes in `macedonian`:
- line 74: \CYRR\cyre\cyrch\cyrn\cyri\cyrk from \CYRR\cyre\cyrc\cyrn\cyri\cyrk
- line 51: Речник from Рецник
- line 111: втор. from вт.