### PR TITLE
Fix typos in ‘babel-mk.ini’

### DIFF
--- a/locale/mk/babel-mk.ini
+++ b/locale/mk/babel-mk.ini
@@ -9,6 +9,7 @@
 ;   http://cldr.unicode.org/
 ;   http://unicode.org/copyright.html
 ; * Some typos fixed by Stojan Trajanovski
+; * Some typos fixed by Dario Gjorgjevski
 
 [identification]
 charset = utf8
@@ -32,7 +33,7 @@ derivate = no
 [captions]
 preface = Предговор
 ref = Литература
-abstract = Абстракт
+abstract = Апстракт
 bib = Библиографиjа
 chapter = Глава
 appendix = Прилог
@@ -48,14 +49,14 @@ cc = копиjа
 headto = За
 page = стр.
 see = види
-also = види истотака
+also = види исто така
 proof = доказ
 glossaryname = Речник
 
 [captions.licr]
 preface = \CYRP\cyrr\cyre\cyrd\cyrg\cyro\cyrv\cyro\cyrr
 ref = \CYRL\cyri\cyrt\cyre\cyrr\cyra\cyrt\cyru\cyrr\cyra
-abstract = \CYRA\cyrb\cyrs\cyrt\cyrr\cyra\cyrk\cyrt
+abstract = \CYRA\cyrp\cyrs\cyrt\cyrr\cyra\cyrk\cyrt
 bib = \CYRB\cyri\cyrb\cyrl\cyri\cyro\cyrg\cyrr\cyra\cyrf\cyri j\cyra
 chapter = \CYRG\cyrl\cyra\cyrv\cyra
 appendix = \CYRP\cyrr\cyri\cyrl\cyro\cyrg
@@ -71,7 +72,7 @@ cc = \cyrk\cyro\cyrp\cyri j\cyra
 headto = \CYRZ\cyra
 page = \cyrs\cyrt\cyrr.
 see = \cyrv\cyri\cyrd\cyri
-also = \cyrv\cyri\cyrd\cyri\space \cyri\cyrs\cyrt\cyro\cyrt\cyra\cyrk\cyra
+also = \cyrv\cyri\cyrd\cyri\space \cyri\cyrs\cyrt\cyro\space \cyrt\cyra\cyrk\cyra
 proof = \cyrd\cyro\cyrk\cyra\cyrz
 glossaryname = \CYRR\cyre\cyrch\cyrn\cyri\cyrk
 


### PR DESCRIPTION
- There should be a space between the words _исто_ and _така_
- The correct word for _Abstract_ is _Апстракт_, not _Абстракт_