### PR TITLE
fix tiny typo in doc for `\localecounter`

### DIFF
--- a/babel.dtx
+++ b/babel.dtx
@@ -2791,7 +2791,7 @@ which is not recommended).
 \end{note}
 
 \Describe{\localenumeral}{\marg{style}\marg{number}}
-\DescribeOther{\localecounterl}{\marg{style}\marg{counter}}
+\DescribeOther{\localecounter}{\marg{style}\marg{counter}}
 
 \New{3.41} Many `ini` locale files has been extended with information
 about non-positional numerical systems, based on those predefined in


### PR DESCRIPTION
Fixes typo `\localecounterl` -> `\localecounter` in `babel.dtx`.