### PR TITLE
robustifying \ensureascii and adding \asciiensure

### DIFF
--- a/babel.dtx
+++ b/babel.dtx
@@ -12278,6 +12278,8 @@ wouldn’t exist.
 \let\org@TeX\TeX
 \let\org@LaTeX\LaTeX
 \let\ensureascii\@firstofone
+\def\asciiencoding{OT1}
+\let\asciiensure\relax
 \AtBeginDocument{%
   \def\@elt#1{,#1,}%
   \edef\bbl@tempa{\expandafter\@gobbletwo\@fontenc@load@list}%

--- a/babel.dtx
+++ b/babel.dtx
@@ -12265,9 +12265,9 @@ wouldn’t exist.
 %  encoding. There is a list of non-ASCII encodings. Requested
 %  encodings are currently stored in |\@fontenc@load@list|. If a
 %  non-ASCII has been loaded, we define versions of |\TeX| and |\LaTeX|
-%  for them using |\ensureascii|. The default ASCII encoding is set,
-%  too (in reverse order): the ``main'' encoding (when the document
-%  begins), the last loaded, or |OT1|.
+%  for them using |\ensureascii|. The default ASCII encoding is set
+%  and stored in |\asciiencoding|, too (in reverse order): the ``main''
+%  encoding (when the document begins), the last loaded, or |OT1|.
 %
 %  \begin{macro}{\ensureascii}
 %
@@ -12300,8 +12300,15 @@ wouldn’t exist.
     \ifin@\else
       \edef\bbl@tempc{\cf@encoding}% The default if ascii wins
     \fi
-    \edef\ensureascii#1{%
-      {\noexpand\fontencoding{\bbl@tempc}\noexpand\selectfont#1}}%
+    \edef\asciiencoding{\bbl@tempc}%
+	\DeclareRobustCommand{\asciiensure}{%
+      \fontencoding{\asciiencoding}\selectfont
+      \def\encodingdefault{\asciiencoding}}%
+	\ifx\@undefined\DeclareTextFontCommand
+	  \DeclareRobustCommand{\ensureascii}[1]{\leavevmode{\asciiensure #1}}%
+	\else
+	  \DeclareTextFontCommand{\ensureascii}{\asciiensure}%
+	\fi
     \DeclareTextCommandDefault{\TeX}{\ensureascii{\org@TeX}}%
     \DeclareTextCommandDefault{\LaTeX}{\ensureascii{\org@LaTeX}}%
   \fi}


### PR DESCRIPTION
I thought it will be useful to have `\asciiensure` (similar to `\latintext`). I also think `\ensureascii` should be robust as it is not expandable (maybe some variant of `\protected` will be preferable? I'm not really sure what is the best way to protect macros in LaTeX these days, but `\DeclareRobustCommand` is how `\latintext` is defined...) 

BTW, why is `\latintext` considered deprecated? just because it does not consider all font encodings or is there anything more fundamental?