### PR TITLE
Small alignments with polyglossia

### DIFF
--- a/locale/hr/babel-hr.ini
+++ b/locale/hr/babel-hr.ini
@@ -146,10 +146,10 @@ time.medium = [HH]:[mm]:[ss]
 time.short = [HH]:[mm]
 
 [typography]
-frenchspacing = no
+frenchspacing = yes
 hyphenrules = croatian
 lefthyphenmin = 2
-righthyphenmin = 3
+righthyphenmin = 2
 hyphenchar = 
 prehyphenchar = 
 posthyphenchar = 


### PR DESCRIPTION
Check:
* https://github.com/reutenauer/polyglossia/blob/26b232dd2d4a2bbe01222a2f9e738dcf79706b52/tex/gloss-croatian.ldf
* https://hyphenation.org/index.html: Croatian	croatian	hr	(2,2)	EC	LPPL	Igor Marinović

@jbezos Additionally, is it possible to arrange the following in babel?
* indentfirst=false, % recommendation from Damir Bralić
* splithyphens https://github.com/reutenauer/polyglossia/commit/0951383e85ffdb433b4411d59dd89334b4405e70
It seems that `transforms.posthyphenation` is the right place (based on Czech and Slovak) but I am not so familiar with it.

Are the other parameters under `typography` somewhere described (e.g. `hyphenationmin`)?