### PR TITLE
A fix for a couple of bugs in hebrew numerals

### DIFF
--- a/locale/he/babel-hebrew.tex
+++ b/locale/he/babel-hebrew.tex
@@ -15,7 +15,7 @@
 \def\BabelHebrewNumeralMarkerSingle{׳}% Number is a single letter
 \def\BabelHebrewNumeralMarkerFinal{״}%  Before final letter
 
-\@namedef{bbl@cntr@letters.long@\CurrentOption}#1%
+\@namedef{bbl@cntr@letters.plain@\CurrentOption}#1%
   {\expandafter\@hebrew@@numeral\expandafter{\the\numexpr#1}0}
 
 \@namedef{bbl@cntr@letters.gershayim@\CurrentOption}#1%

--- a/locale/he/babel-hebrew.tex
+++ b/locale/he/babel-hebrew.tex
@@ -10,7 +10,6 @@
 \BabelBeforeIni{he}{%
 }
 
-\ifcase\bbl@engine\else
 % Contributed by Udi Fogiel, with some changes
 \def\BabelHebrewNumeralMarkerSingle{׳}% Number is a single letter
 \def\BabelHebrewNumeralMarkerFinal{״}%  Before final letter
@@ -129,7 +128,5 @@
       \or\ifnum#2>0 \ifnum#1=9 ט\BabelHebrewNumeralMarkerSingle
         \else\BabelHebrewNumeralMarkerFinal ט\fi\else ט\fi
   \fi\fi\fi}
-
-\fi
 
 \endinput

--- a/locale/he/babel-hebrew.tex
+++ b/locale/he/babel-hebrew.tex
@@ -53,7 +53,7 @@
   
 \def\hebrew@alph@zero{}
 \def\hebrew@num@nomil#1#2{%
-  \ifcase\hebrew@num@trunc{#1}{100}%    print nothing if no hundreds
+  \ifcase\hebrew@num@trunc{#1}{100} % terminating space, do not remove! print nothing if no hundreds
     \or ק\ifnum#2>0 \ifnum#1=100 \BabelHebrewNumeralMarkerSingle\fi\fi
     \or ר\ifnum#2>0 \ifnum#1=200 \BabelHebrewNumeralMarkerSingle\fi\fi
     \or ש\ifnum#2>0 \ifnum#1=300 \BabelHebrewNumeralMarkerSingle\fi\fi
@@ -108,7 +108,7 @@
         \if #22ץ\else צ\fi\ifnum#2>0 \ifnum#1=90 \BabelHebrewNumeralMarkerSingle \fi\fi
       \fi
   \fi
-  \ifcase\numexpr #1-10*\hebrew@num@trunc{#1}{10}%
+  \ifcase\numexpr #1-10*\hebrew@num@trunc{#1}{10} % terminating space, do not remove!
       \hebrew@alph@zero %  empty but can be defined if desired
       \or\ifnum#2>0 \ifnum#1=1 א\BabelHebrewNumeralMarkerSingle
         \else\BabelHebrewNumeralMarkerFinal א\fi\else א\fi


### PR DESCRIPTION
Consider the following:
```tex
\documentclass{article}
\usepackage[bidi=basic, hebrew, provide=*]{babel}

\babelfont{rm}{David CLM}

\begin{document}
\localenumeral{letters.gershayim}{12}
\localenumeral{letters.final}{12}
\localenumeral{letters.plain}{12}

\edef\foo{\localenumeral{letters.gershayim}{12}}\show\foo

\edef\foo{\localenumeral{letters.final}{12}}\show\foo

\edef\foo{\localenumeral{letters.plain}{12}}\show\foo
\end{document}
```

It presents two problems

- notice that `\foo` is `\relax`, which means that `\hebrew@num@nomil` is not expandable. It was due missing terminating spaces after the `\ifcase` tests (they were there on purpues :-)
- `letters.plain` does not work, this is because the internal is named `letters.long`. I assumed that this is a typo and that the documentation is the correct one.

I was wondering why shouldn't these features be allowed in pdftex. I've noticed that the following (after the commits) produce an error
```tex
% !TEX TS-program = pdflatex
\documentclass[a4paper, 12pt]{article}
\usepackage[NHE8]{fontenc}
\usepackage[bidi=default,hebrew, provide=*]{babel}
% \let\gershayim\hebgershayim
\begin{document}
\localenumeral{letters.gershayim}{12}
\localenumeral{letters.final}{12}
\localenumeral{letters.plain}{12}

\edef\foo{\localenumeral{letters.gershayim}{12}}\show\foo

\edef\foo{\localenumeral{letters.final}{12}}\show\foo

\edef\foo{\localenumeral{letters.plain}{12}}\show\foo
\end{document}
```
this is due a bug in the encodings, I had a typo... It should be fixed in the following couple of days. In the meantime adding the line `\let\gershayim\hebgershayim` should fix the problem. If that was the reason for not including pdftex, I think it should be changed.
