### PR TITLE
add missing braces to doc

### DIFF
--- a/babel.dtx
+++ b/babel.dtx
@@ -3167,8 +3167,8 @@ page on the news for 3.76 in the \babel{} site for further details.
 \subsection{Accessing language info}
 
 \Describe{\localename}{}
-\DescribeOther{\mainlocalename}
-\DescribeOther{\languagename}
+\DescribeOther{\mainlocalename}{}
+\DescribeOther{\languagename}{}
 \New{29.10} The control sequence |\localename| contains the name of the current
 locale. This is now the recommended way to retrieve the current
 language. In addtion, |\mainlocalename| contains the main language.


### PR DESCRIPTION
The lines
```tex
\DescribeOther{\mainlocalename}
\DescribeOther{\languagename}
```
in babel.dtx are missing the second argument. I just added `{}` after each.