### PR TITLE
set shapemode to -2 in \bbl@listparshape

### DIFF
--- a/babel.dtx
+++ b/babel.dtx
@@ -16456,7 +16456,7 @@ end
    \def\bbl@listparshape#1#2#3{%
      \parshape #1 #2 #3 %
      \ifnum\bbl@getluadir{page}=\bbl@getluadir{par}\else
-       \shapemode\tw@
+       \shapemode-\tw@
      \fi}}
   {}
 \IfBabelLayout{graphics}


### PR DESCRIPTION
From the LuaTeX manual:

> The value is reset to zero (like \hangindent and \parshape) after the paragraph is done with.
> You can use negative values to prevent this.

but there was a bug in the function that clear paragraph parameters that prevented \shapenode from resetting back to zero even if it was positive, which explains why \bbl@listparshape currently works.

This is fixed in
https://gitlab.lisn.upsaclay.fr/texlive/luatex/-/commit/07c0b354d913a32dd3faf79f05f0f103c55416d0 and will probably be in TL 2025.