### PR TITLE
Fix `oneletter.nobreak` transform for Czech and Slovak

### DIFF
--- a/locale/cs/babel-cs.ini
+++ b/locale/cs/babel-cs.ini
@@ -183,7 +183,7 @@ superscriptingExponent = ×
 [counters]
 
 [transforms.prehyphenation]
-oneletter.nobreak.1.0 = { |[AIiVvOoUuSsZzKk]()|() }
+oneletter.nobreak.1.0 = { |[AaIiVvOoUuSsZzKk]()|() }
 oneletter.nobreak.1.1 =   { insert, penalty=10000 }
 oneletter.nobreak.1.2 =   {}
 

--- a/locale/sk/babel-sk.ini
+++ b/locale/sk/babel-sk.ini
@@ -183,7 +183,7 @@ superscriptingExponent = ×
 [counters]
 
 [transforms.prehyphenation]
-oneletter.nobreak.1.0 = { |[AIiVvOoUuSsZzKk]()|() }
+oneletter.nobreak.1.0 = { |[AaIiVvOoUuSsZzKk]()|() }
 oneletter.nobreak.1.1 =   { insert, penalty=10000 }
 oneletter.nobreak.1.2 =   {}
 


### PR DESCRIPTION
This change adds missing lowercase "a" to `oneletter.nobreak` transform rule for Czech and Slovak locales.