### PR TITLE
Manual corrections concerning Latin

### DIFF
--- a/babel.dtx
+++ b/babel.dtx
@@ -2807,7 +2807,7 @@ be added or removed):\footnote{No predefined “axis” for modifiers
 is provided because languages and their scripts have quite different
 needs.}
 \begin{verbatim}
-\usepackage[latin_.medieval_, spanish_.notilde.lcroman_, danish]{babel}
+\usepackage[latin_.lowercasemonth_, spanish_.notilde.lcroman_, danish]{babel}
 \end{verbatim}
 
 Attributes (described below) are considered modifiers, i.e., you can
@@ -3318,7 +3318,7 @@ languages. The first ones are predefined by \LaTeX{} (see
     iota) to capital iota when uppercasing.
   \item[Latin] |nouv| in |classicallatin| and |medievallatin| reverts
     the default rules, which maps u $\leftrightarrow$ V; |uv| in
-    |ecclesianticallatin| and the basic |latin| locale applies the map
+    |ecclesiasticallatin| and the basic |latin| locale applies the map
     u $\leftrightarrow$ V (by default it’s u $\leftrightarrow$ U and v
     $\leftrightarrow$ V).
 \end{description}
@@ -3896,7 +3896,7 @@ check them, as they may change:\footnote{Thanks to Enrico Gregorio.}
 the manual for Greek) |;|
 \item[Hungarian] |`|
 \item[Kurmanji] |^|
-\item[Latin] |" ^ =|
+\item[Latin] |" ^ ' =|
 \item[Slovak] |" ^ ' -|
 \item[Spanish] |" . < > ' ~|
 \item[Turkish] |: ! =|


### PR DESCRIPTION
The medieval modifier is outdated.
The ' shorthand was missing.