### PR TITLE
Proof environment should use "İspat" instead of "Kanıt"

### DIFF
--- a/locale/tr/babel-tr.ini
+++ b/locale/tr/babel-tr.ini
@@ -47,7 +47,7 @@ headto = Alıcı
 page = Sayfa
 see = bkz.
 also = ayrıca bkz.
-proof = Kanıt
+proof = İspat
 glossary = Lügatçe
 
 [captions.licr]
@@ -70,7 +70,7 @@ headto = Al\i c\i
 page = Sayfa
 see = bkz.
 also = ayr\i ca bkz.
-proof = Kan\i t
+proof = İspat
 glossary = L\"ugat\c ce
 
 [date.gregorian]


### PR DESCRIPTION
In Turkish "kanıt" more cleanly maps onto "evidence" (a weaker term) whereas "ispat" is the term preferred by mathematicians.