### PR TITLE
TR: change "Lügatçe" to "Sözlükçe"

### DIFF
--- a/locale/tr/babel-tr.ini
+++ b/locale/tr/babel-tr.ini
@@ -49,7 +49,7 @@ page = Sayfa
 see = bkz.
 also = ayrıca bkz.
 proof = İspat
-glossary = Lügatçe
+glossary = Sözlükçe
 
 [captions.licr]
 preface = \"Ons\"oz
@@ -72,7 +72,7 @@ page = Sayfa
 see = bkz.
 also = ayr\i ca bkz.
 proof = \.Ispat
-glossary = L\"ugat\c ce
+glossary = S\"ozl\"uk\c ce
 
 [date.gregorian]
 date.long = [d][ ][MMMM] [y]


### PR DESCRIPTION
Origin of the word "Lügat" is Arabic, instead we should use the word "Sözlük" which has Turkish origin and more popular in daily use.