### PR TITLE
remove tcolorbox patches

### DIFF
--- a/babel.dtx
+++ b/babel.dtx
@@ -17067,18 +17067,6 @@ end
         \bbl@sreplace\tikz{\begingroup}{\begingroup\bbl@pictsetdir\tw@}%
         \bbl@sreplace\tikzpicture{\begingroup}{\begingroup\bbl@pictsetdir\tw@}%
       \fi
-      \ifx\tcolorbox\@undefined\else
-        \def\tcb@drawing@env@begin{%
-          \csname tcb@before@\tcb@split@state\endcsname
-          \bbl@pictsetdir\tw@
-          \begin{\kvtcb@graphenv}%
-          \tcb@bbdraw
-          \tcb@apply@graph@patches}%
-        \def\tcb@drawing@env@end{%
-          \end{\kvtcb@graphenv}%
-          \bbl@pictresetdir
-          \csname tcb@after@\tcb@split@state\endcsname}%
-      \fi
     }}
   {}
 %    \end{macrocode}


### PR DESCRIPTION
`\tcb@drawing@env@begin` and `\tcb@drawing@env@end`
are not defined or used for a long time now: https://github.com/T-F-S/tcolorbox/commit/f7f39a4af09b6cce028c0e8e83d6c40f56d899d1 from simple tests these patches are not needed