### PR TITLE
set \fixupboxesmode to positive

### DIFF
--- a/babel.dtx
+++ b/babel.dtx
@@ -16373,7 +16373,6 @@ end
 % necessary with |basic| (24.8), but it’s kept in |basic-r|.
 %
 %    \begin{macrocode}
-\breakafterdirmode=1
 \ifnum\bbl@bidimode>\@ne % Any bidi= except default (=1)
   \let\bbl@beforeforeign\leavevmode
   \AtEndOfPackage{\EnableBabelHook{babel-bidi}}
@@ -16527,6 +16526,8 @@ end
 \ifnum\bbl@bidimode>\z@ % Any bidi=
   \matheqdirmode\@ne        % A luatex primitive
   \mathemptydisplaymode\@ne % Another
+  \breakafterdirmode\@ne % Another
+  \fixupboxesmode\@ne % Another
   \let\bbl@eqnodir\relax
   \def\bbl@eqdel{()}
   \def\bbl@eqnum{%


### PR DESCRIPTION
By default LuaTeX keeps dir nodes balanced
when a group ends by adding appropriate enddir nodes, but it does not do so for the end group of boxes, and for hbox it can be problematic for unboxing:

```tex
\documentclass{article}
\begin{document}
\showoutput
%\fixupboxesmode=1
\setbox0\hbox{\textdirection=1 foo}
\unhbox0\ bar
\end{document}
```

Setting \fixupboxesmode to positive makes LuaTeX fix directions at group end of hbox.