### PR TITLE
support \rotatebox

### DIFF
--- a/babel.dtx
+++ b/babel.dtx
@@ -17041,10 +17041,18 @@ end
      luatexbase.add_to_callback("hpack_filter", Babel.picture_dir,
        "Babel.picture_dir")
    }%
+   \AddToHook{package/graphics/after}{%
+     \bbl@exp{%
+       \\\bbl@sreplace\\\rotatebox{\hbox{{\string#2}}}
+         {\hbox bdir\z@{\hbox bdir\bbl@thetextdir{{\string#2}}}}}}
+   \AddToHook{package/graphicx/after}{%
+     \bbl@exp{%
+       \\\bbl@sreplace\\\Grot@box@std{\hbox{{\string#2}}}
+         {\hbox bdir\z@{\hbox bdir\bbl@thetextdir{{\string#2}}}}%
+       \\\bbl@sreplace\\\Grot@box@kv{\hbox{\string#3}}
+         {{\hbox bdir\z@}{\hbox bdir\bbl@thetextdir{{\string#3}}}}%
+       \\\bbl@sreplace\\\Grot@box{\hbox}{\hbox bdir\z@}}}
    \AtBeginDocument{%
-     \def\LS@rot{%
-       \setbox\@outputbox\vbox{%
-         \hbox dir TLT{\rotatebox{90}{\box\@outputbox}}}}%
      \long\def\put(#1,#2)#3{%
        \@killglue 
        % Try:


### PR DESCRIPTION
You can test with
```tex
\documentclass{article}
\usepackage[hebrew,english,bidi=default,provide*=*,layout=graphics]{babel}
\usepackage{graphicx}

\usepackage{tikz}
\newcommand\baseline[2][red]{\tikz[overlay]\draw[#1](0,0)--++(#2,0);\ignorespaces}
\newcommand\testtext[1]{\fboxsep=0pt \fbox{#1yytt\rule[-10pt]{1pt}{20pt}}}
\newcommand\testangle{90}
\newcommand\testrotate[1]{%
  \fbox{\rotatebox[origin=#1]{\testangle}
        {\ifcase\textdirection\baseline[green]{1}\else\baseline[green]{-1}\fi\testtext{#1}}}}
\newcommand\testsuite[1]{%
     \renewcommand\testangle{#1}
     \ifnum\textdirection=0
     \baseline{20}%
     \else
     \baseline{-20}%
     \fi 
     a\fbox{\testtext{NN}}
     \testrotate{Br}
     \testrotate{Bl}
     \testrotate{lb}
     \testrotate{rb}
     \testrotate{lt}
     \testrotate{rt}
     \testrotate{c}
     }%

\begin{document}
\testsuite{90}

\testsuite{-90}

\testsuite{50}

\testsuite{-50}

\testsuite{180}

\newpage

\selectlanguage{hebrew}

\testsuite{90}

\testsuite{-90}

\testsuite{50}

\testsuite{-50}

\testsuite{180}

\end{document}
```